### PR TITLE
[BUGFIX] make sure date fields are properly empty if no userdata given

### DIFF
--- a/Resources/Private/Templates/Backend/Edit.html
+++ b/Resources/Private/Templates/Backend/Edit.html
@@ -24,10 +24,10 @@
                                     </label>
                                 </div>
                                 <f:if condition="{editableStartStopTime}">
-                                  <div class="groupdelegation__startstop">
-                                        <label for="starttime"><f:translate key="LLL:EXT:lang/locallang_core.xlf:labels.starttime"/></label> <f:form.textfield name="starttime" type="date" value="{f:if(condition: user.starttime, then: user.starttime, else: null) -> f:format.date( format: 'Y-m-d' )}" placeholder="JJJJ-MM-DD" />
-                                        <label for="endtime"><f:translate key="LLL:EXT:lang/locallang_core.xlf:labels.endtime"/></label> <f:form.textfield name="endtime" type="date" value="{f:if(condition: user.endtime, then: user.endtime, else: null) -> f:format.date( format: 'Y-m-d' )}" placeholder="JJJJ-MM-DD" />
-                                  </div>
+                                    <div class="groupdelegation__startstop">
+                                        <label for="starttime"><f:translate key="LLL:EXT:lang/locallang_core.xlf:labels.starttime"/></label> <f:form.textfield name="starttime" type="date" value="{f:if(condition: user.starttime, then: '{user.starttime -> f:format.date( format: \'Y-m-d\' )}', else: '')}" placeholder="JJJJ-MM-DD" />
+                                        <label for="endtime"><f:translate key="LLL:EXT:lang/locallang_core.xlf:labels.endtime"/></label> <f:form.textfield name="endtime" type="date" value="{f:if(condition: user.endtime, then: '{user.endtime -> f:format.date( format: \'Y-m-d\' )}', else: '')}" placeholder="JJJJ-MM-DD" />
+                                    </div>
                                 </f:if>
                             </f:if>
 


### PR DESCRIPTION
with old code we sometimes had the issue that the current date is filled in on opening the edit page, which might lead to filling start / stop date without wanting or realizing it.