### PR TITLE
[REGRESSION] keep support for downloadable TYPO3 with older dependencies

### DIFF
--- a/Classes/Utility/GroupDelegationUtility.php
+++ b/Classes/Utility/GroupDelegationUtility.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace In2code\Groupdelegation\Utility;
 
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\FetchMode;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -104,7 +105,7 @@ class GroupDelegationUtility
             $where .
             $groupBy .
             $orderBy
-        )->fetchAllAssociative();
+        )->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -119,7 +120,7 @@ class GroupDelegationUtility
             ->where($queryBuilder->expr()->eq('admin', 0))
             ->orderBy('username')
             ->execute()
-            ->fetchAllAssociative();
+            ->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**


### PR DESCRIPTION
Installing TYPO3 with composer results in a newer version of doctrine/dbal with the new method, but we want to also support the downloadable TYPO3.